### PR TITLE
Minor changes for BCC2020 workshop

### DIFF
--- a/ex1_bioblend.ipynb
+++ b/ex1_bioblend.ipynb
@@ -15,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -31,9 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -41,15 +37,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3) **Upload** the local file \"~/bioblend-tutorial/test-data/1.txt\" to a new dataset in the created history using `tools.upload_file()` ."
+    "3) **Upload** the local file \"test-data/1.txt\" to a new dataset in the created history using the GalaxyInstance's `tools.upload_file()` ."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -63,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -73,15 +65,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5) **Import a workflow** from the local file \"~/bioblend-tutorial/test-data/convert_to_tab.ga\" using `workflows.import_workflow_from_local_path()` ."
+    "5) **Import a workflow** from the local file \"test-data/convert_to_tab.ga\" using `workflows.import_workflow_from_local_path()` ."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -95,9 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -111,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -127,23 +113,36 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ex1_bioblend.objects.ipynb
+++ b/ex1_bioblend.objects.ipynb
@@ -15,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -31,9 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -41,15 +37,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3) **Upload** the local file \"~/bioblend-tutorial/test-data/1.txt\" to a new dataset in the created history using the `upload_file()` method of `History` objects."
+    "3) **Upload** the local file \"test-data/1.txt\" to a new dataset in the created history using the `upload_file()` method of `History` objects."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -64,15 +58,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5) **Import a workflow** from the local file \"~/bioblend-tutorial/test-data/convert_to_tab.ga\" using `workflows.import_new()` ."
+    "5) **Import a workflow** from the local file \"test-data/convert_to_tab.ga\" using `workflows.import_new()` ."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -86,9 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -102,9 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -118,23 +106,36 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ex1_bioblend.objects_answers.ipynb
+++ b/ex1_bioblend.objects_answers.ipynb
@@ -15,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import bioblend.galaxy.objects\n",
@@ -37,9 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -61,15 +57,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3) **Upload** the local file \"~/bioblend-tutorial/test-data/1.txt\" to a new dataset in the created history using the `upload_file()` method of `History` objects."
+    "3) **Upload** the local file \"test-data/1.txt\" to a new dataset in the created history using the `upload_file()` method of `History` objects."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -84,7 +78,7 @@
    ],
    "source": [
     "import os\n",
-    "hda = new_hist.upload_file(os.path.join(os.environ['HOME'], \"bioblend-tutorial/test-data/1.txt\"))\n",
+    "hda = new_hist.upload_file(\"test-data/1.txt\")\n",
     "hda"
    ]
   },
@@ -99,15 +93,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5) **Import a workflow** from the local file \"~/bioblend-tutorial/test-data/convert_to_tab.ga\" using `workflows.import_new()` ."
+    "5) **Import a workflow** from the local file \"test-data/convert_to_tab.ga\" using `workflows.import_new()` ."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -121,7 +113,7 @@
     }
    ],
    "source": [
-    "with open(os.path.join(os.environ['HOME'], 'bioblend-tutorial/test-data/convert_to_tab.ga'), 'r') as f:\n",
+    "with open('test-data/convert_to_tab.ga', 'r') as f:\n",
     "    wf_string = f.read()\n",
     "wf = gi.workflows.import_new(wf_string)\n",
     "wf"
@@ -137,9 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -166,9 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -198,23 +186,36 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ex1_bioblend.objects_answers.ipynb
+++ b/ex1_bioblend.objects_answers.ipynb
@@ -77,7 +77,6 @@
     }
    ],
    "source": [
-    "import os\n",
     "hda = new_hist.upload_file(\"test-data/1.txt\")\n",
     "hda"
    ]

--- a/ex1_bioblend_answers.ipynb
+++ b/ex1_bioblend_answers.ipynb
@@ -153,7 +153,6 @@
     }
    ],
    "source": [
-    "import os\n",
     "ret = gi.tools.upload_file(\"test-data/1.txt\", new_hist['id'])\n",
     "ret"
    ]

--- a/ex1_bioblend_answers.ipynb
+++ b/ex1_bioblend_answers.ipynb
@@ -363,7 +363,7 @@
     }
    ],
    "source": [
-    "input_step_ids = wf['inputs'].keys()\n",
+    "input_step_ids = list(wf['inputs'].keys())\n",
     "print(input_step_ids)\n",
     "dataset_map = {input_step_ids[0]: {'id': hda['id'], 'src': 'hda'}}\n",
     "ret = gi.workflows.run_workflow(wf['id'], dataset_map=dataset_map, history_id=new_hist['id'])\n",

--- a/ex1_bioblend_answers.ipynb
+++ b/ex1_bioblend_answers.ipynb
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3) **Upload** the local file \"~/bioblend-tutorial/test-data/1.txt\" to a new dataset in the created history using `tools.upload_file()` ."
+    "3) **Upload** the local file \"test-data/1.txt\" to a new dataset in the created history using `tools.upload_file()` ."
    ]
   },
   {
@@ -154,7 +154,7 @@
    ],
    "source": [
     "import os\n",
-    "ret = gi.tools.upload_file(os.path.join(os.environ['HOME'], \"bioblend-tutorial/test-data/1.txt\"), new_hist['id'])\n",
+    "ret = gi.tools.upload_file(\"test-data/1.txt\", new_hist['id'])\n",
     "ret"
    ]
   },
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5) **Import a workflow** from the local file \"~/bioblend-tutorial/test-data/convert_to_tab.ga\" using `workflows.import_workflow_from_local_path()` ."
+    "5) **Import a workflow** from the local file \"test-data/convert_to_tab.ga\" using `workflows.import_workflow_from_local_path()` ."
    ]
   },
   {
@@ -241,7 +241,7 @@
     }
    ],
    "source": [
-    "wf = gi.workflows.import_workflow_from_local_path(os.path.join(os.environ['HOME'], 'bioblend-tutorial/test-data/convert_to_tab.ga'))\n",
+    "wf = gi.workflows.import_workflow_from_local_path('test-data/convert_to_tab.ga')\n",
     "wf"
    ]
   },
@@ -381,21 +381,34 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/ex1_extras.ipynb
+++ b/ex1_extras.ipynb
@@ -17,23 +17,36 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ex1_galaxy_api.ipynb
+++ b/ex1_galaxy_api.ipynb
@@ -15,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -31,9 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -41,15 +37,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3) **Upload** the local file \"~/bioblend-tutorial/test-data/1.txt\" to a new dataset in the created history. You need to run the special 'upload1' tool by making a `POST` request to `/api/tools`. You don't need to pass any inputs to it apart from attaching the file as 'files_0|file_data'."
+    "3) **Upload** the local file \"test-data/1.txt\" to a new dataset in the created history. You need to run the special 'upload1' tool by making a `POST` request to `/api/tools`. You don't need to pass any inputs to it apart from attaching the file as 'files_0|file_data'."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -63,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -73,15 +65,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5) **Import a workflow** from the local file \"~/bioblend-tutorial/test-data/convert_to_tab.ga\" by making a `POST` request to `/api/workflows` (or the deprecated `/api/workflows/upload`). The only needed data is 'workflow', which must be a deserialized JSON representation of the workflow."
+    "5) **Import a workflow** from the local file \"test-data/convert_to_tab.ga\" by making a `POST` request to `/api/workflows` (or the deprecated `/api/workflows/upload`). The only needed data is 'workflow', which must be a deserialized JSON representation of the workflow."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -95,9 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -111,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -127,23 +113,36 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ex1_galaxy_api_answers.ipynb
+++ b/ex1_galaxy_api_answers.ipynb
@@ -159,8 +159,6 @@
     }
    ],
    "source": [
-    "import os\n",
-    "\n",
     "params = {'key': api_key}\n",
     "data = {\n",
     "    'history_id': new_hist['id'],\n",

--- a/ex1_galaxy_api_answers.ipynb
+++ b/ex1_galaxy_api_answers.ipynb
@@ -106,7 +106,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3) **Upload** the local file \"~/bioblend-tutorial/test-data/1.txt\" to a new dataset in the created history. You need to run the special 'upload1' tool by making a `POST` request to `/api/tools`. You don't need to pass any inputs to it apart from attaching the file as 'files_0|file_data'."
+    "3) **Upload** the local file \"test-data/1.txt\" to a new dataset in the created history. You need to run the special 'upload1' tool by making a `POST` request to `/api/tools`. You don't need to pass any inputs to it apart from attaching the file as 'files_0|file_data'."
    ]
   },
   {
@@ -165,7 +165,7 @@
     "data = {\n",
     "    'history_id': new_hist['id'],\n",
     "    'tool_id': 'upload1'}\n",
-    "with open(os.path.join(os.environ['HOME'], \"bioblend-tutorial/test-data/1.txt\"), 'rb') as f:\n",
+    "with open(\"test-data/1.txt\", 'rb') as f:\n",
     "    files = {'files_0|file_data': f}\n",
     "    r = requests.post(base_url + '/tools', data, params=params, files=files)\n",
     "ret = r.json()\n",
@@ -228,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5) **Import a workflow** from the local file \"~/bioblend-tutorial/test-data/convert_to_tab.ga\" by making a `POST` request to `/api/workflows`. The only needed data is 'workflow', which must be a deserialized JSON representation of the workflow."
+    "5) **Import a workflow** from the local file \"test-data/convert_to_tab.ga\" by making a `POST` request to `/api/workflows`. The only needed data is 'workflow', which must be a deserialized JSON representation of the workflow."
    ]
   },
   {
@@ -256,7 +256,7 @@
    ],
    "source": [
     "params = {'key': api_key}\n",
-    "with open(os.path.join(os.environ['HOME'], 'bioblend-tutorial/test-data/convert_to_tab.ga'), 'r') as f:\n",
+    "with open('test-data/convert_to_tab.ga', 'r') as f:\n",
     "    workflow_json = json.load(f)\n",
     "data = {'workflow': workflow_json}\n",
     "r = requests.post(base_url + '/workflows', json.dumps(data), params=params, headers={'Content-Type': 'application/json'})\n",
@@ -407,21 +407,34 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/ex1_galaxy_api_answers.ipynb
+++ b/ex1_galaxy_api_answers.ipynb
@@ -383,7 +383,7 @@
     }
    ],
    "source": [
-    "input_step_ids = wf['inputs'].keys()\n",
+    "input_step_ids = list(wf['inputs'].keys())\n",
     "print(input_step_ids)\n",
     "params = {'key': api_key}\n",
     "dataset_map = {input_step_ids[0]: {'id': hda['id'], 'src': 'hda'}}\n",


### PR DESCRIPTION
Changes:

* A minor suggestion - using local paths for `test-data` rather than `~/bioblend-tutorial/test-data`. This makes things simpler when using Binder I think?
* Add list() as a wrapper around the dict_keys object from the workflow inputs, so that it can be indexed. Modern Python won't allow the result of a keys() call to be indexed.
* This PR has also what I assume are harmless side effects - updated notebook metadata to show that the most recent loaded kernel was Python 3, etc, and updated the nbformat from 4.0 to 4.1. 